### PR TITLE
feat: Update DCM member ordering rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
 ## Unreleased
-
+## 2.0.0
+* upgraded flutter_lints to 2.0.1
+* upgraded dart_code_metrics to 5.5.1
+* remove deprecated rule: invariant_booleans
 ## 1.5.0
 ### Added
 * conditional_uri_does_not_exist rule;

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -26,33 +26,13 @@ Future<void> main() async {
 class OrderExample {
   static const staticConst = 42;
 
-  static const _staticConst = staticConst;
-
   static final staticFinal = staticConst.isEven;
-
-  static final _staticFinal = _staticConst.isEven;
 
   static var staticField = 42;
 
-  static var _staticField = 42;
-
-  final fin = 42;
-
-  final String finalField;
-
-  final _fin = 42;
-
-  String publicField;
-
-  String get string => publicField.toString();
-
-  set string(String newString) => publicField = newString;
-
-  String _privateField = '42';
-
-  String get _field => _privateField;
-
-  set _field(String newString) => _privateField = '42';
+  static void staticFoo() {
+    return;
+  }
 
   OrderExample({
     required this.finalField,
@@ -72,13 +52,27 @@ class OrderExample {
         publicField: publicField,
       );
 
+  final fin = 42;
+
+  final String finalField;
+
+  final _fin = 42;
+
+  String publicField;
+
+  String _privateField = '42';
+
+  String get string => publicField.toString();
+
+  set string(String newString) => publicField = newString;
+
+  String get _field => _privateField;
+
+  set _field(String newString) => _privateField = '42';
+
   @override
   String toString() {
     return super.toString().substring(0);
-  }
-
-  static void staticFoo() {
-    return;
   }
 
   void foo() {
@@ -90,11 +84,19 @@ class OrderExample {
     return;
   }
 
-  static void _staticFoo() {
+  void dispose() {}
+
+  void _foo() {
     return;
   }
 
-  void _foo() {
+  static const _staticConst = staticConst;
+
+  static final _staticFinal = _staticConst.isEven;
+
+  static var _staticField = 42;
+
+  static void _staticFoo() {
     return;
   }
 }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,9 +4,10 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.18.0 <3.0.0"
 
-dev_dependencies:
+dependencies:
   meta: ^1.3.0
   surf_lint_rules:
     path: ../
+

--- a/lib/analysis_options.2.0.0.yaml
+++ b/lib/analysis_options.2.0.0.yaml
@@ -52,29 +52,33 @@ dart_code_metrics:
     - no-equal-then-else
     - prefer-trailing-comma
     - member-ordering:
-        alphabetize: false # TODO set true after code-dart_code_metrics update
+        alphabetize: false
         order:
           - public-static-const-fields
-          - private-static-const-fields
           - public-static-final-fields
-          - private-static-final-fields
           - public-static-fields
-          - private-static-fields
-          - public-final-fields
-          - private-final-fields
-          - public-fields
-          - public-getters-setters
-          - private-fields
-          - private-getters-setters
+          - public-static-methods
           - constructors
           - named-constructors
           - factory-constructors
+          - overridden-final-fields
+          - public-final-fields
+          - private-final-fields
+          - overridden-fields
+          - public-fields
+          - private-fields
+          - overridden-getters-setters
+          - public-getters-setters
+          - private-getters-setters
           - overridden-methods
-          - public-static-methods
           - public-methods
           - protected-methods
-          - private-static-methods
+          - dispose-method
           - private-methods
+          - private-static-const-fields
+          - private-static-final-fields
+          - private-static-fields
+          - private-static-methods
 
 linter:
   rules:
@@ -257,5 +261,3 @@ linter:
     # Pub rules.
     package_names: true
     sort_pub_dependencies: true
-
-

--- a/lib/analysis_options.2.0.0.yaml
+++ b/lib/analysis_options.2.0.0.yaml
@@ -1,0 +1,261 @@
+include: package:flutter_lints/flutter.yaml
+
+analyzer:
+  plugins:
+    - dart_code_metrics
+  exclude:
+    - "build/**"
+  strong-mode:
+    implicit-casts: false
+    implicit-dynamic: false
+  errors:
+    always_use_package_imports: error
+    avoid_dynamic_calls: error
+    avoid_empty_else: error
+    avoid_print: error
+    avoid_relative_lib_imports: error
+    avoid_returning_null_for_future: error
+    avoid_slow_async_io: error
+    avoid_type_to_string: error
+    avoid_types_as_parameter_names: error
+    avoid_web_libraries_in_flutter: error
+    cancel_subscriptions: error
+    close_sinks: error
+    comment_references: error
+    control_flow_in_finally: error
+    empty_statements: error
+    hash_and_equals: error
+    iterable_contains_unrelated_type: error
+    list_remove_unrelated_type: error
+    literal_only_boolean_expressions: error
+    no_adjacent_strings_in_list: error
+    no_duplicate_case_values: error
+    no_logic_in_create_state: error
+    prefer_void_to_null: error
+    test_types_in_equals: error
+    throw_in_finally: error
+    unnecessary_statements: error
+    unrelated_type_equality_checks: error
+    unsafe_html: error
+    use_build_context_synchronously: error
+    use_key_in_widget_constructors: error
+    valid_regexps: error
+
+dart_code_metrics:
+  metrics-exclude:
+    - test/**
+  rules:
+    - always-remove-listener
+    - avoid-returning-widgets
+    - avoid-unnecessary-setstate
+    - binary-expression-operand-order
+    - no-equal-then-else
+    - prefer-trailing-comma
+    - member-ordering:
+        alphabetize: false # TODO set true after code-dart_code_metrics update
+        order:
+          - public-static-const-fields
+          - private-static-const-fields
+          - public-static-final-fields
+          - private-static-final-fields
+          - public-static-fields
+          - private-static-fields
+          - public-final-fields
+          - private-final-fields
+          - public-fields
+          - public-getters-setters
+          - private-fields
+          - private-getters-setters
+          - constructors
+          - named-constructors
+          - factory-constructors
+          - overridden-methods
+          - public-static-methods
+          - public-methods
+          - protected-methods
+          - private-static-methods
+          - private-methods
+
+linter:
+  rules:
+    # Const rules.
+    prefer_const_constructors: true
+    prefer_const_constructors_in_immutables: true
+    prefer_const_declarations: true
+    prefer_const_literals_to_create_immutables: true
+    unnecessary_const: true
+    unnecessary_late: true
+
+    # Error rules.
+    always_use_package_imports: true
+    avoid_dynamic_calls: true
+    avoid_empty_else: true
+    avoid_print: true
+    avoid_relative_lib_imports: true
+    avoid_returning_null_for_future: true
+    avoid_slow_async_io: true
+    avoid_type_to_string: true
+    avoid_types_as_parameter_names: true
+    avoid_web_libraries_in_flutter: true
+    cancel_subscriptions: true
+    close_sinks: true
+    comment_references: true
+    control_flow_in_finally: true
+    empty_statements: true
+    hash_and_equals: true
+    iterable_contains_unrelated_type: true
+    list_remove_unrelated_type: true
+    literal_only_boolean_expressions: true
+    no_adjacent_strings_in_list: true
+    no_duplicate_case_values: true
+    no_logic_in_create_state: true
+    prefer_void_to_null: true
+    test_types_in_equals: true
+    throw_in_finally: true
+    unnecessary_statements: true
+    unrelated_type_equality_checks: true
+    unsafe_html: true
+    use_build_context_synchronously: true
+    use_key_in_widget_constructors: true
+    valid_regexps: true
+
+    # Style rules.
+    always_declare_return_types: true
+    always_put_required_named_parameters_first: true
+    always_require_non_null_named_parameters: true
+    annotate_overrides: true
+    avoid_annotating_with_dynamic: true
+    avoid_bool_literals_in_conditional_expressions: true
+    avoid_catches_without_on_clauses: true
+    avoid_catching_errors: true
+    avoid_equals_and_hash_code_on_mutable_classes: true
+    avoid_escaping_inner_quotes: true
+    avoid_field_initializers_in_const_classes: true
+    avoid_function_literals_in_foreach_calls: true
+    avoid_implementing_value_types: true
+    avoid_init_to_null: true
+    avoid_js_rounded_ints: true
+    avoid_multiple_declarations_per_line: true
+    avoid_null_checks_in_equality_operators: true
+    avoid_positional_boolean_parameters: true
+    avoid_private_typedef_functions: true
+    avoid_redundant_argument_values: true
+    avoid_renaming_method_parameters: true
+    avoid_return_types_on_setters: true
+    avoid_returning_null: true
+    avoid_returning_null_for_void: true
+    avoid_returning_this: true
+    avoid_setters_without_getters: true
+    avoid_shadowing_type_parameters: true
+    avoid_single_cascade_in_expression_statements: true
+    avoid_types_on_closure_parameters: true
+    avoid_unnecessary_containers: true
+    avoid_unused_constructor_parameters: true
+    avoid_void_async: true
+    await_only_futures: true
+    camel_case_extensions: true
+    camel_case_types: true
+    cascade_invocations: true
+    constant_identifier_names: true
+    curly_braces_in_flow_control_structures: true
+    deprecated_consistency: true
+    directives_ordering: true
+    do_not_use_environment: true
+    empty_catches: true
+    empty_constructor_bodies: true
+    exhaustive_cases: true
+    file_names: true
+    implementation_imports: true
+    leading_newlines_in_multiline_strings: true
+    library_names: true
+    library_prefixes: true
+    missing_whitespace_between_adjacent_strings: true
+    no_runtimeType_toString: true
+    non_constant_identifier_names: true
+    null_closures: true
+    omit_local_variable_types: true
+    one_member_abstracts: true
+    only_throw_errors: true
+    overridden_fields: true
+    package_api_docs: true
+    parameter_assignments: true
+    prefer_adjacent_string_concatenation: true
+    prefer_asserts_in_initializer_lists: true
+    prefer_collection_literals: true
+    prefer_conditional_assignment: true
+    prefer_constructors_over_static_methods: true
+    prefer_contains: true
+    prefer_equal_for_default_values: true
+    prefer_final_fields: true
+    prefer_final_in_for_each: true
+    prefer_final_locals: true
+    prefer_for_elements_to_map_fromIterable: true
+    prefer_function_declarations_over_variables: true
+    prefer_generic_function_type_aliases: true
+    prefer_if_elements_to_conditional_expressions: true
+    prefer_if_null_operators: true
+    prefer_initializing_formals: true
+    prefer_inlined_adds: true
+    prefer_interpolation_to_compose_strings: true
+    prefer_is_empty: true
+    prefer_is_not_empty: true
+    prefer_is_not_operator: true
+    prefer_iterable_whereType: true
+    prefer_mixin: true
+    prefer_null_aware_operators: true
+    prefer_single_quotes: true
+    prefer_spread_collections: true
+    prefer_typing_uninitialized_variables: true
+    provide_deprecation_message: true
+    public_member_api_docs: false
+    recursive_getters: true
+    sized_box_for_whitespace: true
+    slash_for_doc_comments: true
+    sort_child_properties_last: false
+    sort_constructors_first: false
+    sort_unnamed_constructors_first: false
+    type_annotate_public_apis: true
+    type_init_formals: true
+    unawaited_futures: true
+    unnecessary_await_in_return: true
+    unnecessary_brace_in_string_interps: true
+    unnecessary_getters_setters: true
+    unnecessary_lambdas: true
+    unnecessary_new: true
+    unnecessary_null_aware_assignments: true
+    unnecessary_null_checks: true
+    unnecessary_null_in_if_null_operators: true
+    unnecessary_nullable_for_final_variable_declarations: true
+    unnecessary_overrides: true
+    unnecessary_parenthesis: true
+    unnecessary_raw_strings: true
+    unnecessary_string_escapes: true
+    unnecessary_string_interpolations: true
+    unnecessary_this: true
+    use_full_hex_values_for_flutter_colors: true
+    use_function_type_syntax_for_parameters: true
+    use_if_null_to_convert_nulls_to_bools: true
+    use_is_even_rather_than_modulo: true
+    use_late_for_private_fields_and_variables: true
+    use_named_constants: true
+    use_raw_strings: true
+    use_rethrow_when_possible: true
+    use_setters_to_change_properties: true
+    use_string_buffers: true
+    use_to_and_as_if_applicable: true
+    void_checks: true
+    lines_longer_than_80_chars: false
+    flutter_style_todos: true
+    conditional_uri_does_not_exist: true
+    no_leading_underscores_for_library_prefixes: true
+    no_leading_underscores_for_local_identifiers: true
+    secure_pubspec_urls: true
+    sized_box_shrink_expand: true
+    use_decorated_box: true
+    use_colored_box: true
+
+    # Pub rules.
+    package_names: true
+    sort_pub_dependencies: true
+
+

--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -1,1 +1,1 @@
-include: package:surf_lint_rules/analysis_options.1.5.0.yaml
+include: package:surf_lint_rules/analysis_options.2.0.0.yaml

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: surf_lint_rules
-version: 1.5.0
+version: 2.0.0
 description: Lint rules for "Surf" company for Dart and Flutter projects.
 repository: "https://github.com/surfstudio/flutter-surf-lint-rules"
 issue_tracker: "https://github.com/surfstudio/flutter-surf-lint-rules/issues"
 
 dependencies:
-  dart_code_metrics: ^4.0.0-dev.2
-  flutter_lints: ^1.0.4
+  dart_code_metrics: ^5.5.1
+  flutter_lints: ^2.0.1
 
 environment:
-  sdk: ">=2.13.0 <3.0.0"
+  sdk: ">=2.18.0 <3.0.0"


### PR DESCRIPTION
# Motivation

Sometimes current rules are awkward, sometimes it contradicts to popular and cosy Flutter [rules](https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#order-other-class-members-in-a-way-that-makes-sense) 

# Common changes

## Separated `static`

Static members are always stands apart a class. 

Public statics must be on top of a class: 
- Public const and final static are most often members you want to see quickly
- Public static methods are something like factory constructors and must be on the top of everything 

Private statics, on the contrary, are something you use only in that class (consts and simple utils). And must be hiding at the bottom of everything. 

## Constructors on top 

1. It's more familiar to Flutter [rules](https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#order-other-class-members-in-a-way-that-makes-sense).
2. When you see new class you want to know it's dependencies firstly 
3. Constructors changes rarely than fields and methods 

## Dispose method on bottom

It's intuitively that dispose method calls on class destroying and places on the bottom of methods.

